### PR TITLE
Repaginar README do perfil com visual moderno

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,71 @@
-![0vbfzhjcsjs0u716x88o](https://user-images.githubusercontent.com/99926224/178134923-f6352f32-196b-49bc-bfa0-563d8293a796.gif)
-
-## 👋Hello Everyone, I'm Thales Ferreira.
-
-## I'm passionate about technology.
-
-### Full Stack Developer | Front-end | Back-end
-
-- I graduated from Trybe and I'm currently working at SMi Tech.
-
-- Technologies learned: HTML | CSS | JAVASCRIPT | REACT | REDUX | JEST | DOCKER | MYSQL | HEROKU | SEQUELIZE | NODE | EXPRESS | JAVA | ANGULAR | VUE | NEXTJS | NESTJS
-
-<div>
-  <a href = "mailto:thalesferreira190@gmail.com"><img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" target="_blank"></a>
-  <a href="https://www.linkedin.com/in/thales-david-ferreira-a47378107/" target="_blank"><img src="https://img.shields.io/badge/-LinkedIn-%230077B5?style=for-the-badge&logo=linkedin&logoColor=white" target="_blank" /></a> 
-  <a href="https://api.whatsapp.com/send?phone=5516992746725" target="_blank"><img src="https://img.shields.io/badge/WhatsApp-25D366?style=for-the-badge&logo=whatsapp&logoColor=white" target="_blank"></a>
-</div>
-
-<div style="display: inline_block">
-  <a href="https://github.com/ThalesDFerreira"/>
-  <img height="180em" src="https://github-readme-stats.vercel.app/api?username=ThalesDFerreira&show_icons=true&theme=dracula&include_all_commits=true&count_private=true"/>
-  <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=ThalesDFerreira&layout=compact&langs_count=7&theme=dark"/>
-</div>
-
-<div style="display: inline_block"><br>
-  <img align="center" alt="Th-HTML" height="60" width="70" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg" />
-  <img align="center" alt="Th-CSS" height="60" width="70" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg" />
-  <img align="center" alt="Th-Js" height="60" width="70" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-plain.svg" />
-  <img align="center" alt="Th-React" height="60" width="70" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg" />
-  <img align="center" alt="Th-Redux" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/redux/redux-original.svg" />
-  <img align="center" alt="Th-Jest" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/jest/jest-plain.svg" />
-  <img align="center" alt="Th-Docker" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" />
-  <img align="center" alt="Th-MySQL" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original-wordmark.svg" />
-  <img align="center" alt="Th-Heroku" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/heroku/heroku-original-wordmark.svg" />
-  <img align="center" alt="Th-Sequelize" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/sequelize/sequelize-original-wordmark.svg" />
-  <img align="center" alt="Th-Node" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original-wordmark.svg" />
-  <img align="center" alt="Th-Express" height="60" width="70" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/express/express-original-wordmark.svg" />
-</div>
-  
-**My Portfolio**
-<div style="display: inline_block">
-  <a href="https://thalesdev.netlify.app/"/>
-  <img align="center" alt="Dev" height="100" width="100" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/devicon/devicon-original.svg" />
-</div>
-    
-**Dio.me Profile**
-<div style="display: inline_block">
-  <a href="https://www.dio.me/users/thalesferreira190"/>
-  <img align="center" alt="Dev" height="100" width="100" src="https://hermes.digitalinnovation.one/assets/diome/logo-full.svg" />
-</div>
-  
 <div align="center">
-  <h2>🐍 My Contributions 🐍</h2>
-  <br>
-  <img alt="snake eating my contributions" src="https://raw.githubusercontent.com/ThalesDFerreira/ThalesDFerreira/output/github-contribution-grid-snake.svg" />
-  
-  <br/><br/><br/>
+
+<img width="100%" src="https://capsule-render.vercel.app/api?type=waving&color=0:6366F1,50:8B5CF6,100:22D3EE&height=190&section=header&text=Thales%20Ferreira&fontColor=ffffff&fontSize=46&fontAlignY=36&desc=Full%20Stack%20Developer&descSize=18&descAlignY=58&animation=fadeIn" />
+
+<a href="https://readme-typing-svg.demolab.com">
+  <img src="https://readme-typing-svg.demolab.com?font=Poppins&size=22&duration=3000&pause=1000&color=22D3EE&center=true&vCenter=true&width=520&lines=Apaixonado+por+tecnologia.;Front-end+%7C+Back-end;Sempre+aprendendo+algo+novo." alt="Typing SVG" />
+</a>
+
 </div>
+
+<br>
+
+<div align="center">
+
+Olá! 👋 Sou **Thales Ferreira**, desenvolvedor Full Stack formado pela **Trybe** e atualmente na **SMi Tech**.
+Gosto de transformar ideias em produtos bem feitos, do front ao back.
+
+</div>
+
+<br>
+
+<div align="center">
+
+<a href="mailto:thalesferreira190@gmail.com"><img src="https://img.shields.io/badge/Gmail-EA4335?style=flat-square&logo=gmail&logoColor=white" /></a>
+<a href="https://www.linkedin.com/in/thales-david-ferreira-a47378107/" target="_blank"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white" /></a>
+<a href="https://api.whatsapp.com/send?phone=5516992746725" target="_blank"><img src="https://img.shields.io/badge/WhatsApp-25D366?style=flat-square&logo=whatsapp&logoColor=white" /></a>
+<a href="https://thalesdev.netlify.app/" target="_blank"><img src="https://img.shields.io/badge/Portfólio-6366F1?style=flat-square&logo=netlify&logoColor=white" /></a>
+<a href="https://www.dio.me/users/thalesferreira190" target="_blank"><img src="https://img.shields.io/badge/DIO-141A2E?style=flat-square&logo=digitalocean&logoColor=white" /></a>
+
+</div>
+
+<br>
+
+<div align="center">
+
+### 🛠️ Tecnologias
+
+<img src="https://skillicons.dev/icons?i=html,css,js,ts,react,redux,jest,nodejs,express&theme=dark" />
+<br>
+<img src="https://skillicons.dev/icons?i=nestjs,nextjs,vue,angular,java,mysql,sequelize,docker&theme=dark" />
+
+</div>
+
+<br>
+
+<div align="center">
+
+### 📊 GitHub Stats
+
+<img height="165em" src="https://github-readme-stats.vercel.app/api?username=ThalesDFerreira&show_icons=true&hide_border=true&include_all_commits=true&count_private=true&title_color=22D3EE&icon_color=818CF8&text_color=94A3B8&bg_color=00000000" />
+<img height="165em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=ThalesDFerreira&layout=compact&langs_count=8&hide_border=true&title_color=22D3EE&text_color=94A3B8&bg_color=00000000" />
+
+<br>
+
+<img src="https://streak-stats.demolab.com?user=ThalesDFerreira&hide_border=true&background=00000000&ring=22D3EE&fire=8B5CF6&currStreakLabel=22D3EE&sideLabels=94A3B8&dates=94A3B8&sideNums=94A3B8&currStreakNum=818CF8&dayLabels=94A3B8&stroke=94A3B8" />
+
+</div>
+
+<br>
+
+<div align="center">
+
+### 🐍 Contribuições
+
+<img alt="snake eating my contributions" src="https://raw.githubusercontent.com/ThalesDFerreira/ThalesDFerreira/output/github-contribution-grid-snake.svg" />
+
+</div>
+
+<br>
+
+<img width="100%" src="https://capsule-render.vercel.app/api?type=waving&color=0:22D3EE,50:8B5CF6,100:6366F1&height=120&section=footer" />


### PR DESCRIPTION
Redesenha a capa do perfil para um visual mais limpo e moderno:
- Banner com gradiente índigo/violeta/ciano (capsule-render) no lugar do GIF
- Intro animada com typing SVG (Poppins)
- Stack via skillicons (tema dark, ícones consistentes) + TypeScript
- Cards de stats e streak com fundo transparente e paleta ciano coesa
- Badges sociais em flat-square; portfólio e DIO viraram badges
- Layout centralizado e arejado com footer em gradiente